### PR TITLE
Fix issue related to pointer storage.

### DIFF
--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -213,7 +213,7 @@ private:
 
 		struct {
 			hash_t name;
-			char   ci;
+			int    ci;
 		} pointer;
 	};
 


### PR DESCRIPTION
I'm not sure what the "ci" field does, but I noticed while testing inkcpp on various platforms that an unexpected crash happens related to it (it having a value of 255).

After some investigation I realized that in every case other than storage, ci is treated as an int. As a matter of fact, various pieces of code expect it to be able to have the values of "255", "0" and "-1", which is impossible for an 8-bit type.

This change fixes my crash and I believe is correct.