### PR TITLE
Properly include cstdio into system.h.

### DIFF
--- a/shared/public/system.h
+++ b/shared/public/system.h
@@ -21,6 +21,7 @@
 #	include <optional>
 #	include <cctype>
 #	include <cstdint>
+#	include <cstdio>
 #	include <cstdarg>
 #endif
 


### PR DESCRIPTION
snprintf is declared in this file. Building using the emscripten compiler fails without this change.