### PR TITLE
Fix compilation with C++17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Build/*
 build/*
 bin/
 Bin/
+
+# Visual Studio
+/out/build/
+/.vs

--- a/inkcpp/include/list.h
+++ b/inkcpp/include/list.h
@@ -96,7 +96,7 @@ public:
 		};
 
 		/** access value the iterator is pointing to */
-		Flag operator*() const { return Flag{.flag_name = _flag_name, .list_name = _list_name}; };
+		Flag operator*() const { return Flag{ _flag_name, _list_name }; };
 
 		/** continue iterator to next value */
 		iterator& operator++()

--- a/inkcpp/include/traits.h
+++ b/inkcpp/include/traits.h
@@ -140,21 +140,21 @@ template<typename T>
 struct string_handler<T&> : string_handler<T> {
 };
 
-#define MARK_AS_STRING(TYPE, LEN, SRC)                  \
-	template<>                                            \
-	struct is_string<TYPE> : constant<bool, true> {       \
-	};                                                    \
-	template<>                                            \
-	struct string_handler<TYPE> {                         \
-		static size_t length(const TYPE& x) { return LEN; } \
-		static void   src_copy(const TYPE& x, char* output) \
-		{                                                   \
-			[&output](const char* src) {                      \
-				while (*src != '\0')                            \
-					*(output++) = *(src++);                       \
-				*output = 0;                                    \
-			}(SRC);                                           \
-		}                                                   \
+#define MARK_AS_STRING(TYPE, LEN, SRC)                                            \
+	template<>                                                                    \
+	struct is_string<TYPE> : constant<bool, true> {                               \
+	};                                                                            \
+	template<>                                                                    \
+	struct string_handler<TYPE> {                                                 \
+		static size_t length(const TYPE& x) { return static_cast<size_t>(LEN); }  \
+		static void   src_copy(const TYPE& x, char* output)                       \
+		{                                                                         \
+			[&output](const char* src) {                                          \
+				while (*src != '\0')                                              \
+					*(output++) = *(src++);                                       \
+				*output = 0;                                                      \
+			}(SRC);                                                               \
+		}                                                                         \
 	}
 
 inline size_t c_str_len(const char* c)


### PR DESCRIPTION
I'm integrating your project into my game, and unfortunately, it's stuck on C++17 for a bit longer. I found that compilation fails on the list header because named parameters are a C++20 feature. However, this is the _only_ place in the codebase that explicitly uses a C++20 feature, so I felt it justified to downgrade it to C++17 for now. I want to upgrade my game to C++20 soon, so feel free to reject this PR if it doesn't align with your vision for the project. I also found a compile warning related to an implicit cast to `ink::size_t` in the string implementation when using STL, so I fixed that and prettied-up the whitespace.