### PR TITLE
Fix various typos in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ ctest -C Release
 To test the python bindings use:
 
 ```sh
-pip install .
 python -m pip install build pytest
 python -m build
 python -m pip install dist/*.whl --user

--- a/inkcpp/functional.cpp
+++ b/inkcpp/functional.cpp
@@ -28,7 +28,7 @@ template<>
 int32_t function_base::pop<int32_t>(basic_eval_stack* stack, list_table& lists)
 {
 	value val = stack->pop();
-	inkAssert(val.type() == value_type::int32, "Type missmatch!");
+	inkAssert(val.type() == value_type::int32, "Type mismatch!");
 	return val.get<value_type::int32>();
 }
 
@@ -36,7 +36,7 @@ template<>
 const char* function_base::pop<const char*>(basic_eval_stack* stack, list_table& lists)
 {
 	value val = stack->pop();
-	inkAssert(val.type() == value_type::string, "Type missmatch!");
+	inkAssert(val.type() == value_type::string, "Type mismatch!");
 	return val.get<value_type::string>().str;
 }
 

--- a/inkcpp/globals_impl.cpp
+++ b/inkcpp/globals_impl.cpp
@@ -26,7 +26,7 @@ globals_impl::globals_impl(const story_impl* story)
 	_visit_counts.resize(_num_containers);
 	_visit_counts_backup.resize(_num_containers);
 	if (_lists) {
-		// initelize static lists
+		// initialize static lists
 		const list_flag* flags = story->lists();
 		while (*flags != null_flag) {
 			list_table::list l = _lists.create_permament();

--- a/inkcpp/include/runner.h
+++ b/inkcpp/include/runner.h
@@ -22,8 +22,8 @@ class choice;
 /**
  * A runner to execute ink script from a story.
  *
- * An independant runner which can execute ink script from a
- * story independant of other runners. Think of the ink story
+ * An independent runner which can execute ink script from a
+ * story independent of other runners. Think of the ink story
  * object like an executable file and the runners as 'threads'
  * (not to be confused with ink threads, which are a language
  * feature). Runners track their own instruction pointer, choice

--- a/inkcpp/include/snapshot.h
+++ b/inkcpp/include/snapshot.h
@@ -13,10 +13,10 @@ namespace ink::runtime
 /**
  * Container for an InkCPP runtime snapshot.
  * Each snapshot contains a @ref ink::runtime::globals_interface "globals store"
- * and all assoziated @ref ink::runtime::runner_interface "runners/threads"
+ * and all associated @ref ink::runtime::runner_interface "runners/threads"
  * For convinience there exist @ref ink::runtime::globals_interface::create_snapshot() and
- * runner_interface::create_snapshot() . If the runner is assoziated to the globals the snapshot
- * will be identical. If multiple runners are assoziated to the same globals all will be contained,
+ * runner_interface::create_snapshot() . If the runner is associated to the globals the snapshot
+ * will be identical. If multiple runners are associated to the same globals all will be contained,
  * and cann be reconsrtucted with the id parameter of @ref
  * ink::runtime::story::new_runner_from_snapshot()
  *
@@ -38,7 +38,7 @@ public:
 	 */
 	static snapshot* from_binary(const unsigned char* data, size_t length, bool freeOnDestroy = true);
 
-	/** acces blob inside snapshot */
+	/** access blob inside snapshot */
 	virtual const unsigned char* get_data() const     = 0;
 	/** size of blob inside snapshot */
 	virtual size_t               get_data_len() const = 0;
@@ -53,7 +53,7 @@ public:
 	static snapshot* from_file(const char* filename);
 	/** serialize snapshot to file
 	 * @param filename output file filename, if already exist it will be overwritten
-	 * @throws ink_exception if it failt to open the file
+	 * @throws ink_exception if it fails to open the file
 	 */
 	void             write_to_file(const char* filename) const;
 #endif

--- a/inkcpp/include/traits.h
+++ b/inkcpp/include/traits.h
@@ -13,7 +13,7 @@
 #	include <string>
 #endif
 
-/** Util templates and implimentation of STL if STL is not available */
+/** Util templates and implementation of STL if STL is not available */
 namespace ink::runtime::internal
 {
 template<typename... Ts>

--- a/inkcpp/include/types.h
+++ b/inkcpp/include/types.h
@@ -25,7 +25,7 @@ using list    = list_interface*;
 
 /** A Ink variable
  *
- * Used for accassing, writing and observing global variables
+ * Used for accessing, writing and observing global variables
  * @ref ink::runtime::globals_interface::get()
  * @ref ink::runtime::globals_interface::set()
  * @ref ink::runtime::globals_interface::observe()

--- a/inkcpp/story_ptr.cpp
+++ b/inkcpp/story_ptr.cpp
@@ -8,68 +8,68 @@
 
 namespace ink::runtime::internal
 {
-	void ref_block::remove_reference(ref_block*& block)
-	{
-		if (block == nullptr)
-			return;
+void ref_block::remove_reference(ref_block*& block)
+{
+	if (block == nullptr)
+		return;
 
-		// If we only have one references left
-		if (block->references <= 1)
-		{
-			// delete the block
-			delete block;
-			block = nullptr;
-			return;
-		}
-
-		// Otherwise, decrement references
-		block->references--;
+	// If we only have one references left
+	if (block->references <= 1) {
+		// delete the block
+		delete block;
+		block = nullptr;
+		return;
 	}
 
-	story_ptr_base::story_ptr_base(internal::ref_block* story)
-		: _story_block(story)
-	{
-		_instance_block = new ref_block();
+	// Otherwise, decrement references
+	block->references--;
+}
+
+story_ptr_base::story_ptr_base(internal::ref_block* story)
+    : _story_block(story)
+{
+	_instance_block = new ref_block();
+}
+
+story_ptr_base::story_ptr_base(internal::ref_block* story, internal::ref_block* instance)
+    : _story_block(story)
+    , _instance_block(instance)
+{
+}
+
+story_ptr_base::story_ptr_base(const story_ptr_base& other)
+    : _story_block(other._story_block)
+    , _instance_block(other._instance_block)
+{
+}
+
+void story_ptr_base::set(const story_ptr_base& other)
+{
+	_story_block    = other._story_block;
+	_instance_block = other._instance_block;
+}
+
+void story_ptr_base::add_reference()
+{
+	// If our block isn't valid, don't bother
+	if (_story_block == nullptr || _instance_block == nullptr || ! _story_block->valid
+	    || ! _instance_block->valid) {
+		_story_block = _instance_block = nullptr;
+		return;
 	}
 
-	story_ptr_base::story_ptr_base(internal::ref_block* story, internal::ref_block* instance)
-		: _story_block(story), _instance_block(instance)
-	{
-	}
+	_instance_block->references++;
+	_story_block->references++;
+}
 
-	story_ptr_base::story_ptr_base(const story_ptr_base& other)
-		: _story_block(other._story_block)
-		, _instance_block(other._instance_block)
-	{
-	}
+bool story_ptr_base::remove_reference()
+{
+	ref_block::remove_reference(_story_block);
+	ref_block::remove_reference(_instance_block);
 
-	void story_ptr_base::set(const story_ptr_base& other)
-	{
-		_story_block = other._story_block;
-		_instance_block = other._instance_block;
-	}
+	bool is_destroyed = _instance_block == nullptr;
 
-	void story_ptr_base::add_reference()
-	{
-		// If our block isn't valid, don't bother
-		if (_story_block == nullptr || _instance_block == nullptr || !_story_block->valid || !_instance_block->valid)
-		{
-			_story_block = _instance_block = nullptr;
-			return;
-		}
-
-		_instance_block->references++;
-		_story_block->references++;
-	}
-
-	bool story_ptr_base::remove_reference()
-	{
-		ref_block::remove_reference(_story_block);
-		ref_block::remove_reference(_instance_block);
-
-		bool is_destroyed = _instance_block == nullptr;
-
-		_instance_block = _story_block = nullptr;
-		return is_destroyed;
-	}
-  } // namespace ink::runtime::internal
+	_instance_block = _story_block = nullptr;
+	return is_destroyed;
+}
+} // namespace ink::runtime::internal

--- a/inkcpp/story_ptr.cpp
+++ b/inkcpp/story_ptr.cpp
@@ -22,7 +22,7 @@ namespace ink::runtime::internal
 			return;
 		}
 
-		// Otherwise, derecement references
+		// Otherwise, decrement references
 		block->references--;
 	}
 

--- a/inkcpp/string_table.h
+++ b/inkcpp/string_table.h
@@ -12,36 +12,36 @@
 
 namespace ink::runtime::internal
 {
-	// hash tree sorted by string pointers
-	class string_table final : public snapshot_interface
-	{
-	public:
-		virtual ~string_table();
+// hash tree sorted by string pointers
+class string_table final : public snapshot_interface
+{
+public:
+	virtual ~string_table();
 
-		// Create a dynamic string of a particular length
-		char* create(size_t length);
-		char* duplicate(const char* str);
+	// Create a dynamic string of a particular length
+	char* create(size_t length);
+	char* duplicate(const char* str);
 
-		// zeroes all usage values
-		void clear_usage();
+	// zeroes all usage values
+	void clear_usage();
 
-		// mark a string as used
-		void mark_used(const char* string);
+	// mark a string as used
+	void mark_used(const char* string);
 
 
-		// snapshot interface implementation
-		size_t snap(unsigned char* data, const snapper&) const;
-		const unsigned char* snap_load(const unsigned char* data, const loader&);
+	// snapshot interface implementation
+	size_t               snap(unsigned char* data, const snapper&) const;
+	const unsigned char* snap_load(const unsigned char* data, const loader&);
 
-		// get position of string when iterate through data
-		// used to enable storing a string table references
-		size_t get_id(const char* string) const;
+	// get position of string when iterate through data
+	// used to enable storing a string table references
+	size_t get_id(const char* string) const;
 
-		// deletes all unused strings
-		void gc();
+	// deletes all unused strings
+	void gc();
 
-	private:
-		avl_array<const char*, bool, ink::size_t, 100> _table;
-	  static constexpr const char*                   EMPTY_STRING = "\x03";
-  };
-}
+private:
+	avl_array<const char*, bool, ink::size_t, 100> _table;
+	static constexpr const char*                   EMPTY_STRING = "\x03";
+};
+} // namespace ink::runtime::internal

--- a/inkcpp/string_table.h
+++ b/inkcpp/string_table.h
@@ -18,7 +18,7 @@ namespace ink::runtime::internal
 	public:
 		virtual ~string_table();
 
-		// Create a dynmaic string of a particular length
+		// Create a dynamic string of a particular length
 		char* create(size_t length);
 		char* duplicate(const char* str);
 

--- a/inkcpp_python/tests/conftest.py
+++ b/inkcpp_python/tests/conftest.py
@@ -32,7 +32,6 @@ def story_path(tmpdir_factory):
             
 @pytest.fixture(scope='session', autouse=True)
 def assets(story_path, inklecate_cmd):
-    print(ink.__dict__, file=sys.stderr)
     res = {}
     for (name, files) in story_path.items():
         if not os.path.exists(files[0]):

--- a/inkcpp_python/tests/test_ExternalFunctions.py
+++ b/inkcpp_python/tests/test_ExternalFunctions.py
@@ -16,7 +16,7 @@ class TestExternalFunctions:
         assert out == "Call1 glued to Call 2\n"
         assert cnt.cnt == 3
         out = runner.getline()
-        assert out == "Call 3 is seperated\n"
+        assert out == "Call 3 is separated\n"
         assert cnt.cnt == 4
 
     def test_lookahadeUnsafe(self, assets, generate):
@@ -30,6 +30,6 @@ class TestExternalFunctions:
         assert out == "glued to Call 2\n"
         assert cnt.cnt == 2
         out = runner.getline()
-        assert out == "Call 3 is seperated\n"
+        assert out == "Call 3 is separated\n"
         assert cnt.cnt == 3
     

--- a/inkcpp_test/LabelCondition.cpp
+++ b/inkcpp_test/LabelCondition.cpp
@@ -10,7 +10,7 @@ using namespace ink::runtime;
 
 SCENARIO( "run story with hidden choice" )
 {
-	GIVEN( "a story with choice visible by second visit" )
+	GIVEN("a story with choice visible by second visit")
 	{
 		auto    ink     = story::from_file(INK_TEST_RESOURCE_DIR "LabelConditionStory.bin");
 		globals globals = ink->new_globals();

--- a/inkcpp_test/LabelCondition.cpp
+++ b/inkcpp_test/LabelCondition.cpp
@@ -10,7 +10,7 @@ using namespace ink::runtime;
 
 SCENARIO( "run story with hidden choice" )
 {
-	GIVEN( "a story with choice visibale by second visit" )
+	GIVEN( "a story with choice visible by second visit" )
 	{
 		auto    ink     = story::from_file(INK_TEST_RESOURCE_DIR "LabelConditionStory.bin");
 		globals globals = ink->new_globals();

--- a/inkcpp_test/LookaheadSafe.cpp
+++ b/inkcpp_test/LookaheadSafe.cpp
@@ -25,7 +25,7 @@ SCENARIO("A story with external functions and glue", "[external]")
 			REQUIRE(cnt == 3);
 			REQUIRE(out == "Call1 glued to Call 2\n");
 			out = thread->getline();
-			REQUIRE(out == "Call 3 is seperated\n");
+			REQUIRE(out == "Call 3 is separated\n");
 			REQUIRE(cnt == 4);
 		}
 		WHEN("the function is not lookahead save")

--- a/inkcpp_test/LookaheadSafe.cpp
+++ b/inkcpp_test/LookaheadSafe.cpp
@@ -39,7 +39,7 @@ SCENARIO("A story with external functions and glue", "[external]")
 			REQUIRE(out == "glued to Call 2\n");
 			REQUIRE(cnt == 2);
 			out = thread->getline();
-			REQUIRE(out == "Call 3 is seperated\n");
+			REQUIRE(out == "Call 3 is separated\n");
 			REQUIRE(cnt == 3);
 		}
 	}

--- a/inkcpp_test/MoveTo.cpp
+++ b/inkcpp_test/MoveTo.cpp
@@ -28,11 +28,11 @@ SCENARIO("run a story, but jump around manually", "[move_to]")
 				REQUIRE(main->num_choices() == 1);
 				REQUIRE(main->get_choice(0)->text() == std::string("Hellow mister menistery"));
 				main->choose(0);
-				REQUIRE(main->getall() == "Hellow mister menistery\nYou are head to head to the minister\nIt seems you are out of options, you shold give up\n");
+				REQUIRE(main->getall() == "Hellow mister menistery\nYou are head to head to the minister\nIt seems you are out of options, you should give up\n");
 			}
 		}
 
-		WHEN("skip intorduction")
+		WHEN("skip introduction")
 		{
 			main->move_to(ink::hash_string("Dialog.core"));
 			THEN("expect output minus introduction")
@@ -41,7 +41,7 @@ SCENARIO("run a story, but jump around manually", "[move_to]")
 				REQUIRE(main->num_choices() == 1);
 				REQUIRE(main->get_choice(0)->text() == std::string("Hellow mister menistery"));
 				main->choose(0);
-				REQUIRE(main->getall() == "Hellow mister menistery\nYou are head to head to the minister\nIt seems you are out of options, you shold give up\n");
+				REQUIRE(main->getall() == "Hellow mister menistery\nYou are head to head to the minister\nIt seems you are out of options, you should give up\n");
 			}
 		}
 
@@ -57,7 +57,7 @@ SCENARIO("run a story, but jump around manually", "[move_to]")
 				REQUIRE(main->num_choices() == 1);
 				REQUIRE(main->get_choice(0)->text() == std::string("Hellow mister menistery"));
 				main->choose(0);
-				REQUIRE(main->getall() == "Hellow mister menistery\nYou are head to head to the minister\nIt seems you are out of options, you shold give up\n");
+				REQUIRE(main->getall() == "Hellow mister menistery\nYou are head to head to the minister\nIt seems you are out of options, you should give up\n");
 			}
 		}
 		WHEN("second runner modifies value")
@@ -71,10 +71,10 @@ SCENARIO("run a story, but jump around manually", "[move_to]")
 				REQUIRE(main->num_choices() == 1);
 				REQUIRE(main->get_choice(0)->text() == std::string("Roar"));
 				main->choose(0);
-				REQUIRE(main->getall() == "Grrrrh, Roarrr\nThe people are quit confused\nYou are head to head to the minister\nIt seems you are out of options, you shold give up\n");
+				REQUIRE(main->getall() == "Grrrrh, Roarrr\nThe people are quit confused\nYou are head to head to the minister\nIt seems you are out of options, you should give up\n");
 			}
 		}
-		WHEN("execute mutliple small runners with sideeffects")
+		WHEN("execute multiple small runners with sideeffects")
 		{
 			main->move_to(ink::hash_string("Dialog.core"));
 			side->move_to(ink::hash_string("Transformations.ToTiger"));
@@ -88,7 +88,7 @@ SCENARIO("run a story, but jump around manually", "[move_to]")
 				REQUIRE(main->num_choices() == 1);
 				REQUIRE(main->get_choice(0)->text() == std::string("Roar"));
 				main->choose(0);
-				REQUIRE(main->getall() == "Grrrrh, Roarrr\nThe people are quit confused\nYou are head to head to the minister\nIt seems you are out of options, you shold give up\n");
+				REQUIRE(main->getall() == "Grrrrh, Roarrr\nThe people are quit confused\nYou are head to head to the minister\nIt seems you are out of options, you should give up\n");
 			}
 		}
 	}

--- a/inkcpp_test/ink/LookaheadSafe.ink
+++ b/inkcpp_test/ink/LookaheadSafe.ink
@@ -10,5 +10,5 @@ Call1
 ~ foo()
 <> glued to Call 2
 ~ foo()
-Call 3 is seperated
+Call 3 is separated
 -> DONE

--- a/inkcpp_test/ink/MoveTo.ink
+++ b/inkcpp_test/ink/MoveTo.ink
@@ -30,7 +30,7 @@ You are head to head to the minister
 	The people are quit confused
 * {Form == Humen} Hellow mister menistery
 * ->
-	It seems you are out of options, you shold give up
+	It seems you are out of options, you should give up
 	-> END
 - -> core
 	

--- a/unreal/inkcpp/Source/inkcpp/Private/InkList.cpp
+++ b/unreal/inkcpp/Source/inkcpp/Private/InkList.cpp
@@ -18,7 +18,7 @@ bool UInkList::ContainsFlag(const FString& flag_name) const
 bool UInkList::ContainsEnum(const UEnum* Enum, const uint8& value) const
 {
 	if (! Enum) {
-		UE_LOG(InkCpp, Warning, TEXT("No Enum provided for ContainsEnum, it will fail therfore!"));
+		UE_LOG(InkCpp, Warning, TEXT("No Enum provided for ContainsEnum; therefore ContainsEnum has failed!"));
 		return false;
 	}
 

--- a/unreal/inkcpp/Source/inkcpp/Private/InkList.cpp
+++ b/unreal/inkcpp/Source/inkcpp/Private/InkList.cpp
@@ -18,7 +18,10 @@ bool UInkList::ContainsFlag(const FString& flag_name) const
 bool UInkList::ContainsEnum(const UEnum* Enum, const uint8& value) const
 {
 	if (! Enum) {
-		UE_LOG(InkCpp, Warning, TEXT("No Enum provided for ContainsEnum; therefore ContainsEnum has failed!"));
+		UE_LOG(
+		    InkCpp, Warning,
+		    TEXT("No Enum provided for ContainsEnum; therefore ContainsEnum has failed!")
+		);
 		return false;
 	}
 

--- a/unreal/inkcpp/Source/inkcpp/Private/InkRuntime.cpp
+++ b/unreal/inkcpp/Source/inkcpp/Private/InkRuntime.cpp
@@ -101,7 +101,7 @@ void AInkRuntime::Tick(float DeltaTime)
 	{
 		UInkThread* pNextThread = *iter;
 
-		// Ignore threads that aren't eligable for execution
+		// Ignore threads that aren't eligible for execution
 		if (!pNextThread->CanExecute())
 			continue;
 

--- a/unreal/inkcpp/Source/inkcpp/Public/InkAsset.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkAsset.h
@@ -12,8 +12,8 @@
 
 /** Assets containing a InkCPP .bin.
  * Asset can be constructed from a `.ink.json` file outputted from inky or inklecate.
- * And generally also directly from a `.ink` file (it may fail if the shipped version of inklecate is
- * incompatible with your system).
+ * And generally also directly from a `.ink` file (it may fail if the shipped version of inklecate
+ * is incompatible with your system).
  *
  * @todo Please note that reimport does not work properly if your ink file has includes.
  * Since the reimport only watches the main file for changes.

--- a/unreal/inkcpp/Source/inkcpp/Public/InkAsset.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkAsset.h
@@ -10,10 +10,10 @@
 
 #include "InkAsset.generated.h"
 
-/** Assets contanining a InkCPP .bin.
- * Asset can be constructed from a `.ink.json` file outputed from inky or inklecate.
- * And generall also directly from a `.ink` file (it may fail if the shipped version of inklecate is
- * incopatible with your system).
+/** Assets containing a InkCPP .bin.
+ * Asset can be constructed from a `.ink.json` file outputted from inky or inklecate.
+ * And generally also directly from a `.ink` file (it may fail if the shipped version of inklecate is
+ * incompatible with your system).
  *
  * @todo Please note that reimport does not work properly if your ink file has includes.
  * Since the reimport only watches the main file for changes.

--- a/unreal/inkcpp/Source/inkcpp/Public/InkChoice.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkChoice.h
@@ -32,7 +32,7 @@ public:
 	FString GetText() const;
 
 	UFUNCTION(BlueprintPure, Category="Ink")
-	/** Get idintifcator for @ref UInkThread::PickChoice()
+	/** Get identifier for @ref UInkThread::PickChoice()
 	 * @return id used in @ref UInkThread::PickChoice()
 	 *
 	 * @blueprint
@@ -40,8 +40,8 @@ public:
 	int GetIndex() const;
 
 	UFUNCTION(BlueprintPure, Category="Ink")
-	/** Tags asszoiated with the choice.
-	 * @return with choice assoziated tags
+	/** Tags associated with the choice.
+	 * @return with choice associated tags
 	 *
 	 * @blueprint
 	 */

--- a/unreal/inkcpp/Source/inkcpp/Public/InkDelegates.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkDelegates.h
@@ -39,9 +39,9 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FTagFunctionMulticastDelegate, UInk
 #ifdef DOXYGEN
 DOC_UF(BlueprintImplementableEvent, )
 /** Delegate for external functions.
- * the number of arugments are defined iside the ink story
+ * the number of arguments are defined inside the ink story
  * @param Arguments array containing all arguments passed to this function
- * @return value to be put on the stack in the inkruntime
+ * @return value to be put on the stack in the ink runtime
  * @see @ref UInkThread::RegisterExternalEvent
  *
  * @blueprint
@@ -103,9 +103,9 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FVariableCallbackDelegateNewValue, const FInkV
 
 #ifdef DOXYGEN
 DOC_UF(BlueprintImplementableEvent, )
-/** Notification containing old and new varible, send on variable change.
+/** Notification containing old and new variable, send on variable change.
  * @param value new value of the variable
- * @param old_value previouse value of the variable has value @ref EInkVarType::None "None" if
+ * @param old_value previous value of the variable has value @ref EInkVarType::None "None" if
  * variable is set for the first time
  * @see @ref AInkRuntime::ObserverVariableChange()
  *
@@ -126,12 +126,12 @@ class UDelegateKeepAlive : public UObject
 };
 
 /** @page TagFunction TagFunction
- * "tag functions" allowes converting tags or context lines to function calls
+ * "tag functions" allows converting tags or context lines to function calls
  * if a tag in the form `functionName_arg1_arg2` is found for a registered tag function
  * the function will be executed
  *
  * Also if a context line starts with a `>>` the normal processing of tags and context
- * will be ignored the corresponding tag functino will be called
+ * will be ignored the corresponding tag function will be called
  * the format for this function call is `>> FunctionName(Arg1[, Arg2]*)`
  *
  * @see To bind tag functions use @ref UInkThread::RegisterTagFunction() and @ref

--- a/unreal/inkcpp/Source/inkcpp/Public/InkList.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkList.h
@@ -28,7 +28,7 @@ struct FListFlag {
 };
 
 /**
- * Allowes reading ink lists.
+ * Allows reading ink lists.
  * @ingroup unreal
  */
 UCLASS(Blueprintable, BlueprintType)
@@ -86,7 +86,7 @@ public:
 
 	UFUNCTION(BlueprintPure, Category = "Ink")
 	/** check if at least one value of the given list is included, OR the list is empty
-	 * and assoziatet with the list
+	 * and associated with the list
 	 *
 	 * @blueprint
 	 */

--- a/unreal/inkcpp/Source/inkcpp/Public/InkRuntime.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkRuntime.h
@@ -23,7 +23,7 @@ class UInkThread;
 struct FInkVar;
 namespace ink::runtime { class story; }
 
-/** Instanciated story with global variable storage and access, used to instanciate new threads.
+/** Instantiated story with global variable storage and access, used to instantiate new threads.
  * @ingroup unreal
  */
 UCLASS()
@@ -63,7 +63,7 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "Ink")
 	/**
-	 * Loads a snapshot file, therfore deletes globals and invalidate all current Threads
+	 * Loads a snapshot file, therefore deletes globals and invalidate all current Threads
 	 * After this Start and StartExisting will load the corresponding Threads (on at a time)
 	 *
 	 * @blueprint
@@ -90,14 +90,14 @@ public:
 	
 	UFUNCTION(BlueprintCallable, Category="Ink")
 	/** register a "tag function"
-	 * This function is executed if context or a tag in a special format apears
+	 * This function is executed if context or a tag in a special format appears
 	 * @see @ref TagFunction
 	 *
 	 * @blueprint
 	 */
 	void RegisterTagFunction(FName functionName, const FTagFunctionDelegate & function);
 
-	/** @private for interanl use */
+	/** @private for internal use */
 	void HandleTagFunction(UInkThread* Caller, const TArray<FString>& Params);
 	
 	UFUNCTION(BlueprintCallable, Category="Ink")
@@ -137,7 +137,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category="Ink")
 	/** On variable change provides old and new value.
 	 * @see #ObserverVariableEvent() #ObserverVariable()
-	 * @attention if the varibale set for the firs time, the old value has value type @ref
+	 * @attention if the variable set for the firs time, the old value has value type @ref
 	 * EInkVarType::None
 	 *
 	 * @blueprint

--- a/unreal/inkcpp/Source/inkcpp/Public/InkSnapshot.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkSnapshot.h
@@ -8,7 +8,7 @@
 
 #include "InkSnapshot.generated.h"
 
-/** A serelizable snapshot of a runtime state
+/** A serializable snapshot of a runtime state
  * Can be used as variable in a USaveGame to be stored and reloaded
  * @ingroup unreal
  */

--- a/unreal/inkcpp/Source/inkcpp/Public/InkThread.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkThread.h
@@ -36,12 +36,12 @@ public:
 
 	// Yields the thread immediately. Will wait until Resume().
 	UFUNCTION(BlueprintCallable, Category = "Ink")
-	/** Yields the thread immediatly.
+	/** Yields the thread immediately.
 	 * This will stop the execution (after finishing the current line).
 	 * until @ref #Resume() is called.
 	 *
-	 * @ref #Yield() and @ref #Resume() working with a refernce counter.
-	 * therfore a thread can be yield multiple times, and must then be resumed
+	 * @ref #Yield() and @ref #Resume() working with a reference counter.
+	 * therefore a thread can be yield multiple times, and must then be resumed
 	 * the same amount.
 	 *
 	 * @blueprint
@@ -83,7 +83,7 @@ public:
 
 	// Called before the thread begins executing
 	UFUNCTION(BlueprintImplementableEvent, Category = "Ink")
-	/** triggered after initalizing the runner
+	/** triggered after initializing the runner
 	 *
 	 * @blueprint
 	 */
@@ -91,9 +91,9 @@ public:
 
 	// Called when the thread has printed a new line
 	UFUNCTION(BlueprintImplementableEvent, Category = "Ink")
-	/** triggerd if a new line of context is available
+	/** triggered if a new line of context is available
 	 * @param line text of new line
-	 * @param tags tags assoziated with this line
+	 * @param tags tags associated with this line
 	 *
 	 * @blueprint
 	 */
@@ -109,7 +109,7 @@ public:
 
 	UFUNCTION(BlueprintImplementableEvent, Category = "Ink")
 	/** triggered when reached a choice point.
-	 * @param choices possible branches to choos for continue
+	 * @param choices possible branches to choose from, in order to continue
 	 * @see #PickChoice()
 	 *
 	 * @blueprint
@@ -197,7 +197,7 @@ private:
 private:
 	ink::runtime::runner mpRunner;
 	UTagList*            mpTags;
-	TArray<UInkChoice*>  mCurrentChoices; /// @TODO: make accassible?
+	TArray<UInkChoice*>  mCurrentChoices; /// @TODO: make accessible?
 
 	TMap<FName, FTagFunctionMulticastDelegate> mTagFunctions;
 

--- a/unreal/inkcpp/Source/inkcpp/Public/InkVar.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkVar.h
@@ -27,7 +27,7 @@ enum class EInkVarType : uint8
 {
 	Float,  ///< contains a value of type float
 	Int,    ///< contains a value of type int or uint
-	UInt,   ///< @todo currenty not supported
+	UInt,   ///< @todo currently not supported
 	Bool,   ///< contains a boolean
 	String, ///< contains a string value
 	List,   ///< contains a @ref UInkList
@@ -80,7 +80,7 @@ struct INKCPP_API FInkVar
 	ink::runtime::value to_value() const;
 
 
-	// allow changing via Editor, but not in controle flow, it is just a wrapper type to create a new one
+	// allow changing via Editor, but not in control flow, it is just a wrapper type to create a new one
 	// UPROPERTY(EditAnywhere, Category = "Ink")
 	/** @private */
 	TUnion<float, int, unsigned, bool, FString, UInkList*> value;
@@ -142,7 +142,7 @@ public:
 
 	UFUNCTION(BlueprintPure, meta = (DisplayName = "Int (Ink Var)", CompactNodeTitle = "->", BlueprintAutocast), Category = "Ink")
 	/** Access Int/Uint value
-	 * @todo suppurt unsigned int
+	 * @todo support unsigned int
 	 *
 	 * @blueprint
 	 */
@@ -163,7 +163,7 @@ public:
 	static FName Conv_InkVarName(const FInkVar& InkVar);
 
 	UFUNCTION(BlueprintPure, meta = (DisplayName = "Text (Ink Var)", CompactNodeTitle = "->", BlueprintAutocast), Category = "Ink")
-	/** Access Strnig value as FText
+	/** Access String value as FText
 	 *
 	 * @blueprint
 	 */

--- a/unreal/inkcpp/Source/inkcpp/Public/InkVar.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkVar.h
@@ -80,8 +80,8 @@ struct INKCPP_API FInkVar
 	ink::runtime::value to_value() const;
 
 
-	// allow changing via Editor, but not in control flow, it is just a wrapper type to create a new one
-	// UPROPERTY(EditAnywhere, Category = "Ink")
+	// allow changing via Editor, but not in control flow, it is just a wrapper type to create a new
+	// one UPROPERTY(EditAnywhere, Category = "Ink")
 	/** @private */
 	TUnion<float, int, unsigned, bool, FString, UInkList*> value;
 

--- a/unreal/inkcpp/Source/inkcpp/Public/TagList.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/TagList.h
@@ -35,10 +35,10 @@ public:
 
 	UFUNCTION(BlueprintPure, Category = "Ink")
 	/** Check if tag list contains enum flag.
-	 * Check if one of the enum flag string represntations is equal
+	 * Check if one of the enum flag string representations is equal
 	 * to one flag in the list.
 	 * @param Enum the enum class to check flags from
-	 * @param value of the flag iff one was found
+	 * @param value of the flag if one was found
 	 * @retval true if a flag was found
 	 * @attention if multiple flags are present in the list, only the first will be returned
 	 * @see #GetEnum()
@@ -56,7 +56,7 @@ public:
 	FString GetValue(const FString& name) const;
 
 	UFUNCTION(BlueprintPure, Category = "Ink")
-	/** Searches for a tag thats begins with 'EnumName:' and returns the enum value corresponding to
+	/** Searches for a tag that begins with 'EnumName:' and returns the enum value corresponding to
 	 * the text after the ':'
 	 * @attention If the enum appears multiple times, the first instance will be used
 	 * @retval true if a tag in the form "EnumName:FlagName" was found

--- a/unreal/inkcpp/Source/inkcpp/Public/inkcpp.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/inkcpp.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup unreal Unreal Blueprints
  * Blueprint Classes usable in Unreal. An example can be found
- * [here](../unreal/InkCPP_DEMO.zip), do not forgett to install the plugin via the
+ * [here](../unreal/InkCPP_DEMO.zip), do not forget to install the plugin via the
  * [marketplace](https://www.unrealengine.com/marketplace/product/inkcpp) or unzipping the
  * `unreal_X_x.zip` from the [release page](https://github.com/JBenda/inkcpp/releases/latest) to
  * `/AN_TEMP_DIRECTORY/` and build it with:
@@ -18,12 +18,12 @@
  * /UNREAL_ENGINE/Build/BatchFiles/RunUAT.bat BuildPlugin
  * -plugin=/AN_TEMP_DIRECTORY/inkcpp/inkcpp.uplugin -package=/YOUR_UNREAL_PROJECT/Plugins/inkcpp
  * -TargetPlatforms=Win64`
- * ``` <br/> And eitherway activating the plugin.
+ * ``` <br/> And either way activating the plugin.
  *
  * The C++ API will be available soon([Issue](https://github.com/JBenda/inkcpp/issues/60)).
  *
  * + @ref ue_setup "General setup"
- * + @ref ue_components "UE5 Blueprits"
+ * + @ref ue_components "UE5 Blueprints"
  * + @ref ue_example "Demo project & setup"
  *
  * @section ue_setup Setup
@@ -56,33 +56,33 @@
  *
  * @subsection ue_runtime Runtime
  * The @ref AInkRuntime handles the runtime as actor.
- * At every Tick all @ref UInkThread of the runtime will be further executed if appropiate.
+ * At every Tick all @ref UInkThread of the runtime will be further executed if appropriate.
  *
  * The asset containing the story to run can be set via the Ink|InkAsset attribute.
  *
  * The runtime is the position to set observer (e.g. @ref AInkRuntime::ObserverVariableChange() )
  * and create new threads  (@ref AInkRuntime::Start() & @ref AInkRuntime::StartExisting() ).
  *
- * It is adviced to create you own Blueprint which inherites @ref AInkRuntime to overwrite the
+ * It is advised to create you own Blueprint which inherits @ref AInkRuntime to overwrite the
  * events as necessary.
  *
  * @subsection ue_thread Thread
- * A @ref UInkThread is like a pointer inside the story. It contains informations can advance and
- * will therby output the context it encounters.
+ * A @ref UInkThread is like a pointer inside the story. It contains information can advance and
+ * will thereby output the context it encounters.
  *
  * All threads inside the same runtime will share the same variables but can be at different points
  * in the story.
  *
- * The most importent events/functions are:
+ * The most important events/functions are:
  * + @ref UInkThread::OnLineWritten() which is called by each new line of output
- * + @ref UInkThread::OnChoice() which is called if a choice is encounterd and must be handled
+ * + @ref UInkThread::OnChoice() which is called if a choice is encountered and must be handled
  * + @ref UInkThread::PickChoice()  to pick a choice and continue the thread.
  *
  * @subsection ue_choice Choice
  * A @ref UInkChoice contains all data relevant for a branch at a choice point.
  * + @ref UInkChoice::GetText() the text of the choice
  * + @ref UInkChoice::GetIndex() the index used in @ref UInkThread::PickChoice()
- * + @ref UInkChoice::GetTags() tags assoziated with this branch/choice
+ * + @ref UInkChoice::GetTags() tags associated with this branch/choice
  *
  * @subsection ue_taglist TagList
  * A @ref UTagList is a wrapper for the array of tags each line of context and each choice can have.
@@ -96,10 +96,10 @@
  *
  * @subsection ue_list InkList
  * @ref UInkList is a wrapper for the list type inside ink.
- * A ink list is like a set for enum values. For a in depth explenation please refer to the [offical
+ * A ink list is like a set for enum values. For a in depth explanation please refer to the [official
  * guide](https://blueprintue.com/blueprint/hdybtdjp/)
  *
- * If you define Enums simular to the Lists in the ink script you can use them for an easier access.
+ * If you define Enums similar to the Lists in the ink script you can use them for an easier access.
  *
  * @section ue_example The Example project
  *
@@ -113,7 +113,7 @@
  * inside
  * `/PATH/InkCPP_DEMO/Plugins/`.
  *
- * Next open the project via the `InkCPP_DEMO/InkCPP_DEMO.uproject` flie.
+ * Next open the project via the `InkCPP_DEMO/InkCPP_DEMO.uproject` file.
  *
  * Than you can hit play to run the demo.
  *
@@ -121,10 +121,10 @@
  * + @ref ue_example_demo "`Demo`": An extensive example demonstrating many but not all features
  * provided by inkCPP like:
  *   + snapshots: for creating save games
- *   + observers: to easily refelct a variable of the ink story in the game.
+ *   + observers: to easily reflect a variable of the ink story in the game.
  *   + external function + yield: to stop playing the story while the game plays a transition
  *   + a second runner: for a inventory menu
- *   + interopariblity between UE Enums and Lists in Ink
+ *   + interoperability between UE Enums and Lists in Ink
  *   + Tag attributes: use tags to modify showed text
  *   + Tag attributes as enums: use tags to modify choices
  * + @ref ue_example_minimal "`Minimal`": An example for a minimal, still sensible usage example of
@@ -139,24 +139,24 @@
  * 2. Load an existing save game if its exists (the Save game is stored at
  * `InkCPP_DEMO/Saved/SaveGames`).
  * 3. Create the main thread of class `DemoThread` and register the external function.
- * 4. Create menu thread(`InfoThread`), set path to `Wait` to avoid any output in the beginging.
+ * 4. Create menu thread(`InfoThread`), set path to `Wait` to avoid any output in the beginning.
  * 5. Set observer for the variable `Heath` to update the healthbar.
  * 6. Set observer for the variable `Inventory` to update the inventory columns.
  *
  * @subsubsection ue_example_ui UI
  *
  * + `DialogHUD` contains all static UI elements.
- *   + `Context`: text box containing thelines of the ink story.
+ *   + `Context`: text box containing the lines of the ink story.
  *   + `Choices`: A container which should be populated with the choice buttons
  *   + `Clues` & `Potions`: container which should be populated with inventory buttons
- *   + `SC_Button`: Button to triggern save and close action
+ *   + `SC_Button`: Button to trigger save and close action
  *   + `Health`: health bar showing current health
  *   + `DMG_Numbers`: container which should be populated with damage numbers
  *   + `Popup`/`PopupContext`/`PopopChoices`: elements needed for the Info/"Item interaction thread"
  *   + `TransitionBlob`: A animated entity used to simulate a transition.
  * + `DMG_Number` animated text block used to display damage numbers
- * + `InventoryButton`/`ChoiceButton`: Wrapper for buttons, primarly for attaching data
- *    to a button for a parametrized clicked event.
+ * + `InventoryButton`/`ChoiceButton`: Wrapper for buttons, primarily for attaching data
+ *    to a button for a parameterized clicked event.
  *
  * @subsubsection ue_example_demo_DemoRunner DemoRunner
  *

--- a/unreal/inkcpp/Source/inkcpp/Public/inkcpp.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/inkcpp.h
@@ -96,8 +96,8 @@
  *
  * @subsection ue_list InkList
  * @ref UInkList is a wrapper for the list type inside ink.
- * A ink list is like a set for enum values. For a in depth explanation please refer to the [official
- * guide](https://blueprintue.com/blueprint/hdybtdjp/)
+ * A ink list is like a set for enum values. For a in depth explanation please refer to the
+ * [official guide](https://blueprintue.com/blueprint/hdybtdjp/)
  *
  * If you define Enums similar to the Lists in the ink script you can use them for an easier access.
  *


### PR DESCRIPTION
Some of these spelling errors show up in blueprints so it's a good idea to fix them so designers understand the nodes clearly. I didn't do a pass on _all_ files; just files that I happened to open or debug.