### PR TITLE
Don't use std::string::starts_with.

### DIFF
--- a/inkcpp_compiler/json_compiler.cpp
+++ b/inkcpp_compiler/json_compiler.cpp
@@ -138,7 +138,8 @@ void json_compiler::compile_container(
 	bool           is_knot = name_override != "" && index_in_parent == -1;
 	if (is_knot) {
 		// it is not a wave or choice
-		if (name_override.starts_with("c-") || name_override.starts_with("g-")) {
+		if (::ink::internal::starts_with(name_override.c_str(), "c-")
+		    || ::ink::internal::starts_with(name_override.c_str(), "g-")) {
 			is_knot = false;
 			for (auto itr = name_override.begin() + 2; itr != name_override.end(); ++itr) {
 				if (*itr > '9' || *itr < '0') {

--- a/shared/public/system.h
+++ b/shared/public/system.h
@@ -97,6 +97,19 @@ constexpr list_flag empty_flag{-1, 0};
 
 namespace internal
 {
+	/** Checks if a string starts with a given prefix*/
+	static bool starts_with(const char* string, const char* prefix)
+	{
+		while (*prefix) {
+			if (*string != *prefix) {
+				return false;
+			}
+			string++;
+			prefix++;
+		}
+		return true;
+	}
+
 	/** Checks if a string is only whitespace*/
 	static bool is_whitespace(const char* string, bool includeNewline = true)
 	{


### PR DESCRIPTION
This is a C++20 feature. This change is required to support C++17, at
least on non-msvc compilers.

The functionality is replaced with an ink-internal alternative.