### PR TITLE
Update list_table::count to return `int32_t`

### DIFF
--- a/inkcpp/list_table.cpp
+++ b/inkcpp/list_table.cpp
@@ -454,7 +454,7 @@ list_table::list list_table::sub(list arg, int n)
 
 list_flag list_table::sub(list_flag arg, int i) { return add(arg, -i); }
 
-int list_table::count(list_flag lf) const
+int32_t list_table::count(list_flag lf) const
 {
 	if (lf == empty_flag || lf == null_flag || lf.flag == -1) {
 		return 0;
@@ -465,7 +465,7 @@ int list_table::count(list_flag lf) const
 	return 1;
 }
 
-int list_table::count(list l) const
+int32_t list_table::count(list l) const
 {
 	int           count = 0;
 	const data_t* data  = getPtr(l.lid);

--- a/inkcpp/list_table.h
+++ b/inkcpp/list_table.h
@@ -179,8 +179,8 @@ public:
 
 	bool not_bool(list_flag lf) const { return ! to_bool(lf); }
 
-	int count(list l) const;
-	int count(list_flag f) const;
+	int32_t count(list l) const;
+	int32_t count(list_flag f) const;
 
 	list_flag min(list l) const;
 


### PR DESCRIPTION
On some platforms like the Playdate console, `int` and  `int32_t` aren't the same type
This change allows the correct template specialization for `value::set` to be found and fixes compilation