### PR TITLE
Update WIN32 ifdef checks to _MSC_VER 

### DIFF
--- a/inkcpp_compiler/binary_emitter.cpp
+++ b/inkcpp_compiler/binary_emitter.cpp
@@ -14,7 +14,7 @@
 #include <map>
 #include <fstream>
 
-#ifndef WIN32
+#ifndef _MSC_VER
 #	include <cstring>
 #endif
 
@@ -26,7 +26,7 @@ using std::string;
 
 char* strtok_s(char* s, const char* sep, char** context)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#ifdef _MSC_VER
 	return ::strtok_s(s, sep, context);
 #else
 	if (context == nullptr || sep == nullptr || (s == nullptr && *context == nullptr)) {

--- a/inkcpp_compiler/reporter.cpp
+++ b/inkcpp_compiler/reporter.cpp
@@ -68,7 +68,7 @@ namespace ink::compiler::internal
 		_list = list;
 
 		// Make sure our buffer is empty
-#ifdef WIN32
+#ifdef _MSC_VER
 		_Tidy();
 #endif
 	}
@@ -90,7 +90,7 @@ namespace ink::compiler::internal
 
 		// Clear our state
 		_list = nullptr;
-#ifdef WIN32
+#ifdef _MSC_VER
 		_Tidy();
 #endif
 


### PR DESCRIPTION
These code paths are wrapped with windows platform `#ifdef` checks but appear to be more specific to the compiler
Making these changes means I can compile with both MSVC and GCC (via MinGW) on Windows

 Also just want to check, does us skipping this buffer clearing step on other compilers cause any issues?
 I don't have a good idea of the lifetime of the `error_strbuf` object
```c++
// Make sure our buffer is empty
#ifdef _MSC_VER
    _Tidy();
#endif
```
