### PR TITLE
Fix optional::emplace()

### DIFF
--- a/shared/public/system.h
+++ b/shared/public/system.h
@@ -269,13 +269,13 @@ public:
 	{
 	}
 
-	const T& operator*() const { return _value; }
+	const T& operator*() const { return value(); }
 
-	T& operator*() { return _value; }
+	T& operator*() { return value(); }
 
-	const T* operator->() const { return &_value; }
+	const T* operator->() const { return &value(); }
 
-	T* operator->() { return &_value; }
+	T* operator->() { return &value(); }
 
 	constexpr bool has_value() const { return _has_value; }
 
@@ -302,8 +302,12 @@ public:
 	template<typename... Args>
 	T& emplace(Args... args)
 	{
-		_value.~T();
-		return *(new (&_value) T(args...));
+		if (_has_value)
+			_value.~T();
+
+		new (&_value) T(args...);
+		_has_value = true;
+		return _value;
 	}
 
 private:


### PR DESCRIPTION
This wasn't marking the newly-constructed value present.
Also replace unchecked access to _value with checked access for the various operators.

This manifested as an exception when running into fallback choices, as the newly-emplaced() choice container wasn't valid at runner_impl.cpp(1379).

NB: For context, I'm doing an experimental integration into a non-Unreal, non-STL, non-EH C++ game engine, so probably using some things in ways they aren't normally used. I had to do some config fiddling to get things working but with this fix it's running nicely with not too much code on my side :) 

If you're interested I can turn the config changes into a PR as well, but that probably needs some discussion about the best way to make them.