### PR TITLE
Make library inkcpp_shared public

### DIFF
--- a/inkcpp/CMakeLists.txt
+++ b/inkcpp/CMakeLists.txt
@@ -52,8 +52,8 @@ target_include_directories(inkcpp PUBLIC
 set_target_properties(inkcpp PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
 
 # Make sure the include directory is included 
-target_link_libraries(inkcpp_o PRIVATE inkcpp_shared)
-target_link_libraries(inkcpp PRIVATE inkcpp_shared)
+target_link_libraries(inkcpp_o PUBLIC inkcpp_shared)
+target_link_libraries(inkcpp PUBLIC inkcpp_shared)
 # Make sure this project and all dependencies use the C++17 standard
 target_compile_features(inkcpp PUBLIC cxx_std_17)
 

--- a/inkcpp_compiler/CMakeLists.txt
+++ b/inkcpp_compiler/CMakeLists.txt
@@ -22,8 +22,8 @@ target_include_directories(inkcpp_compiler PUBLIC
 FILE(GLOB PUBLIC_HEADERS "include/*")
 set_target_properties(inkcpp_compiler PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
 
-target_link_libraries(inkcpp_compiler PRIVATE inkcpp_shared)
-target_link_libraries(inkcpp_compiler_o PRIVATE inkcpp_shared)
+target_link_libraries(inkcpp_compiler PUBLIC inkcpp_shared)
+target_link_libraries(inkcpp_compiler_o PUBLIC inkcpp_shared)
 
 # Unreal installation
 list(REMOVE_ITEM SOURCES "json.hpp")


### PR DESCRIPTION
### Context
Currently, using `add_subdirectory` or `FetchContent` in a CMake project fails to compile. The compiler reports missing headers from the **_inkcpp_shared_** library. A workaround is to explicitly link it:

> target_link_libraries(inkcpp_sample PRIVATE inkcpp inkcpp_compiler **inkcpp_shared**)

However, this is only a quick fix.
### Problem
**_inkcpp_shared_** is a header-only library defined as an `INTERFACE` target and is used in the public headers of the **_inkcpp_** and **_inkcpp_compiler_** projects. However, both projects link **_inkcpp_shared_** as a `PRIVATE` dependency, which prevents its headers from being propagated to consumers.
This issue is not visible when **_inkcpp_** is installed, because the public headers from **_inkcpp_shared_** are copied during installation.
### Solution
To fix the problem, **_inkcpp_shared_** should be linked `PUBLIC` so that its headers are properly propagated as part of the public API of both **_inkcpp_** and **_inkcpp_compiler_**.