### PR TITLE
Update InkThread.h for Tag Crashes

### DIFF
--- a/unreal/inkcpp/Source/inkcpp/Public/InkThread.h
+++ b/unreal/inkcpp/Source/inkcpp/Public/InkThread.h
@@ -223,9 +223,17 @@ private:
 
 private:
 	ink::runtime::runner mpRunner;
+
+	UPROPERTY()
 	UTagList*            mpTags;
+
+	UPROPERTY()
 	UTagList*            mkTags = nullptr;
+
+	UPROPERTY()
 	UTagList*            mgTags = nullptr;
+
+	UPROPERTY()
 	TArray<UInkChoice*>  mCurrentChoices; /// @TODO: make accessible?
 
 	TMap<FName, FTagFunctionMulticastDelegate> mTagFunctions;


### PR DESCRIPTION
My system crashed because there was no UPROPERTY() on these UTagList and UInkChoice pointers, leaving them unprotected from UE's garbage collector.