### PR TITLE
Add support for jumping without resetting the callstack

### DIFF
--- a/inkcpp/include/runner.h
+++ b/inkcpp/include/runner.h
@@ -62,9 +62,13 @@ public:
 	 * to the content at the specified path.
 	 *
 	 * @param path path to search and move execution to
+	 * @param reset_callstack If true, discard the call stack when moving.
+	 * This is the default, safe, behaviour. Otherwise retain the current
+	 * stack as far as possible.
+	 * 
 	 * @return If the path was found
 	 */
-	virtual bool move_to(hash_t path) = 0;
+	virtual bool move_to(hash_t path, bool reset_callstack = true) = 0;
 
 	/**
 	 * Moves the runner to the specified path.
@@ -73,9 +77,12 @@ public:
 	 * to the content at the specified path.
 	 *
 	 * @param path path to search and move execution to
+	 * @param reset_callstack If true, discard the call stack when moving.
+	 * This is the default, safe, behaviour. Otherwise retain the current
+	 * stack as far as possible.
 	 * @return If the path was found
 	 */
-	bool move_to(const char* path) { return move_to(ink::hash_string(path)); }
+	bool move_to(const char* path, bool reset_callstack = true) { return move_to(ink::hash_string(path), reset_callstack); }
 
 	/**
 	 * Can the runner continue?

--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -823,7 +823,7 @@ const char* runner_impl::getline_alloc()
 	return res;
 }
 
-bool runner_impl::move_to(hash_t path)
+bool runner_impl::move_to(hash_t path, bool reset_callstack)
 {
 	// find the path
 	ip_t destination = _story->find_offset_for(path);
@@ -832,9 +832,13 @@ bool runner_impl::move_to(hash_t path)
 		return false;
 	}
 
-	// Clear state and move to destination
-	reset();
-	_ptr = _story->instructions();
+	// Clear state if requested,
+	if (reset_callstack) {
+		reset();
+		_ptr = _story->instructions();
+	}
+
+	// Don't track visit (are we sure this is right?)
 	const bool record_visits    = false;
 	const bool track_knot_visit = false;
 	jump(destination, record_visits, track_knot_visit);

--- a/inkcpp/runner_impl.h
+++ b/inkcpp/runner_impl.h
@@ -129,7 +129,7 @@ public:
 	virtual const char* getline_alloc() override;
 
 	// move to path
-	virtual bool move_to(hash_t path) override;
+	virtual bool move_to(hash_t path, bool reset_callstack = true) override;
 
 	// move to path but keep as much state as possible
 	bool migrate_to(const loader& loader, hash_t path);


### PR DESCRIPTION
Based on similar experimental code in the C# runtime.

I use this for jumping back to the start of the current knot, in order to implement dialogue which can be cancelled and restarted cleanly, so the player doesn't miss out on important information.

E.g. 	

`SIL_VERIFY(m_runner->move_to(m_runner->get_current_knot(), false));`

@JBenda is this something you'd be interested in? It needs a bit more work to make it complete, but IMO the idea is useful.