### PR TITLE
Fix build on targets where int32_t is not int (LIST_VALUE)

### DIFF
--- a/inkcpp/list_operations.h
+++ b/inkcpp/list_operations.h
@@ -334,9 +334,9 @@ public:
 		inkAssert(vals[0].type() == value_type::list_flag, "LIST_VALUE only works on list_flag values");
 		list_flag flag = vals[0].get<value_type::list_flag>();
 		if (flag.list_id < 0 || flag.flag < 0) {
-			stack.push(value{}.set<value_type::int32>(0));
+			stack.push(value{}.set<value_type::int32>(int32_t{0}));
 		} else {
-			stack.push(value{}.set<value_type::int32>(_list_table.get_flag_value(flag)));
+			stack.push(value{}.set<value_type::int32>(static_cast<int32_t>(_list_table.get_flag_value(flag))));
 		}
 	}
 };
@@ -352,9 +352,9 @@ public:
 		list_table::list l        = vals[0].get<value_type::list>();
 		list_flag        max_flag = _list_table.max(l);
 		if (max_flag.list_id < 0 || max_flag.flag < 0) {
-			stack.push(value{}.set<value_type::int32>(0));
+			stack.push(value{}.set<value_type::int32>(int32_t{0}));
 		} else {
-			stack.push(value{}.set<value_type::int32>(_list_table.get_flag_value(max_flag)));
+			stack.push(value{}.set<value_type::int32>(static_cast<int32_t>(_list_table.get_flag_value(max_flag))));
 		}
 	}
 };

--- a/inkcpp/list_operations.h
+++ b/inkcpp/list_operations.h
@@ -336,7 +336,9 @@ public:
 		if (flag.list_id < 0 || flag.flag < 0) {
 			stack.push(value{}.set<value_type::int32>(int32_t{0}));
 		} else {
-			stack.push(value{}.set<value_type::int32>(static_cast<int32_t>(_list_table.get_flag_value(flag))));
+			stack.push(
+			    value{}.set<value_type::int32>(static_cast<int32_t>(_list_table.get_flag_value(flag)))
+			);
 		}
 	}
 };
@@ -354,7 +356,9 @@ public:
 		if (max_flag.list_id < 0 || max_flag.flag < 0) {
 			stack.push(value{}.set<value_type::int32>(int32_t{0}));
 		} else {
-			stack.push(value{}.set<value_type::int32>(static_cast<int32_t>(_list_table.get_flag_value(max_flag))));
+			stack.push(
+			    value{}.set<value_type::int32>(static_cast<int32_t>(_list_table.get_flag_value(max_flag)))
+			);
 		}
 	}
 };


### PR DESCRIPTION
`value::set<value_type::int32>` is specialized on `int32_t`, and **`int32_t` is not `int` on every target** — on Xtensa (ESP32) it is `long`.

The four `LIST_VALUE` call sites added in #162 pass a bare `0` and the `int` returned by `get_flag_value()`, so on those platforms overload resolution selects the primary template rather than the specialization and the build stops:

```
value.h:132: error: static assertion failed: No setter for this type defined!
    required from list_operations.h:254
```

It compiles on x86-64 and arm64 Linux/macOS, where `int32_t` *is* `int`, which is why CI did not catch it.

Every other `set<value_type::int32>` call site in the tree already converts explicitly — `numeric_operations.h`, `container_operations.cpp`, `runner_impl.cpp` — so this just follows the existing convention rather than introducing one.

Found building for ESP32-S3. `ctest` passes.
